### PR TITLE
(fix)  bypass root route in lazarus

### DIFF
--- a/src/Horse.BasicAuthentication.pas
+++ b/src/Horse.BasicAuthentication.pas
@@ -78,8 +78,12 @@ var
   LBase64String: string;
   LBasicAuthenticationDecode: TStringList;
   LIsAuthenticated: Boolean;
+  LPathInfo: string;
 begin
-  if MatchText(Req.RawWebRequest.PathInfo, Config.SkipRoutes) then
+  LPathInfo := Req.RawWebRequest.PathInfo;
+  if LPathInfo = EmptyStr then
+    LPathInfo := '/';
+  if MatchText(LPathInfo, Config.SkipRoutes) then
   begin
     Next();
     Exit;


### PR DESCRIPTION
in Lazarus the Req.Web Request.PathInfo returns empty for the '/' route, so if this route is in the skip route, lazarus was not recognizing it.

```delphi
...
  THorse.Use(HorseBasicAuthentication(DoLogin, THorseBasicAuthenticationConfig.New.SkipRoutes(['/']) ));  

  THorse
    .Get('/ping', GetPing)
    .Get('/', GetRoot);      
...
```